### PR TITLE
bower.json syntax fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,8 @@
     "angular"
   ],
   "dependencies": {
-    "angular": "~1.0.8",
-  ],
+    "angular": "~1.0.8"
+  },
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
Currently it's not possible to install Angular-NestedSortable via bower (`bower install Angular-NestedSortable`).
