### PR TITLE
Improved touch behavior

### DIFF
--- a/angular-nestedSortable.js
+++ b/angular-nestedSortable.js
@@ -268,8 +268,12 @@ angular.module('ui.nestedSortable', [])
 						return;
 						
 					var moveObj = e;
-					if (e !== null && moveObj.type === "touchstart" && moveObj.targetTouches !== undefined) {
-						moveObj = e.targetTouches.item(0);
+					if (e !== null && e.type === "touchstart") {
+						if (e.targetTouches !== undefined) {
+							moveObj = e.targetTouches.item(0);
+						} else if (e.originalEvent !== undefined && e.originalEvent.targetTouches !== undefined) {
+							moveObj = e.originalEvent.targetTouches.item(0);
+						}
 					}
 
 					e.preventDefault();
@@ -303,6 +307,7 @@ angular.module('ui.nestedSortable', [])
 
 					angular.element($window).bind('mouseup', dragEndEvent);
 					angular.element($window).bind('touchend', dragEndEvent); // Mobile
+					angular.element($window).bind('touchcancel', dragEndEvent); // Mobile
 					angular.element($window).bind('mousemove', dragMoveEvent);
 					angular.element($window).bind('touchmove', dragMoveEvent); // Mobile
 				};
@@ -312,7 +317,11 @@ angular.module('ui.nestedSortable', [])
 				{
 					var moveObj = e;
 					if (e !== null && e.type === "touchmove") {
-						moveObj = e.touches.item(0);
+						if (e.touches !== undefined) {
+							moveObj = e.touches.item(0);
+						} else if (e.originalEvent !== undefined && e.originalEvent.touches !== undefined) {
+							moveObj = e.originalEvent.touches.item(0);
+						}
 					}
 					if (dragElm) {
 						e.preventDefault();
@@ -477,6 +486,7 @@ angular.module('ui.nestedSortable', [])
 
 					angular.element($window).unbind('mouseup', dragEndEvent);
 					angular.element($window).unbind('touchend', dragEndEvent); // Mobile
+					angular.element($window).unbind('touchcancel', dragEndEvent); // Mobile
 					angular.element($window).unbind('mousemove', dragMoveEvent);
 					angular.element($window).unbind('touchmove', dragMoveEvent); // Mobile
 				}


### PR DESCRIPTION
As explained in #10 it would be better to define a `touchcancel` event handler as well for cases where the touch event was ended abrupt.
I also added support for jQuery. jQuery actually emulates a normal event and provides the native event (touch event) as a property called `originalEvent`. To obtain the X and Y coördinates of the touch event, we need to retrieve it from `event.originalEvent.touches.item(0)` in stead of `event.touches.item(0)`. I added an additional `if` statement to verify if there is an `originalEvent` property defined or not. Without it, the touch events won't work when used in combination with jQuery.

I personally think jQuery should not wrap it, but I suppose they won't change that.
