### PR TITLE
fixed travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
+  - "0.10"
 
 before_install:
   - "export DISPLAY=:99.0"


### PR DESCRIPTION
nvm node version os not a float, it's a string
