### PR TITLE
Fix dropped callback not invoked

### DIFF
--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -806,7 +806,7 @@
                     if (selectedElementScope.$$apply && !cancel) {
                       selectedElementScope.$dragInfo.apply(scope.$treeScope.copy);
 
-                      selectedElementScope.$apply(function() {
+                      scope.$treeScope.$apply(function() {
                         scope.$treeScope.$callbacks.dropped(dragInfoEventArgs);
                       });
                       dragInfoEventArgs.dest.nodesScope.$apply(function() {


### PR DESCRIPTION
It seems that the dropped() callback is not invoked, please look at this plunker http://plnkr.co/edit/kspEDnmZj7FA4GvAWOHo.

The problem looks strange, it seems that after this invocation:

```
selectedElementScope.$dragInfo.apply(scope.$treeScope.copy);
```

The variable `selectedElementScope.$apply` becomes equal to `angular.noop` so the next time `$apply` is used it will practically do nothing, and the `dropped` callback won't be invoked:

```
selectedElementScope.$apply(function() {
  scope.$treeScope.$callbacks.dropped(dragInfoEventArgs);
});
```
