### PR TITLE
#243: make styling more table friendly

### DIFF
--- a/source/angular-ui-tree.css
+++ b/source/angular-ui-tree.css
@@ -14,7 +14,6 @@
 }
 
 .angular-ui-tree-nodes {
-	display: block;
 	position: relative;
 	margin: 0px;
 	padding: 0px;
@@ -30,7 +29,6 @@
 }
 
 .angular-ui-tree-node, .angular-ui-tree-placeholder {
-	display: block;
 	position: relative;
 	margin: 0px;
 	margin-bottom: 5px;

--- a/source/angular-ui-tree.scss
+++ b/source/angular-ui-tree.scss
@@ -14,7 +14,6 @@
 }
 
 .angular-ui-tree-nodes {
-	display: block;
 	position: relative;
 	margin: 0px;
 	padding: 0px;
@@ -25,7 +24,6 @@
     padding-left: 20px;
 }
 .angular-ui-tree-node, .angular-ui-tree-placeholder {
-	display: block;
 	position: relative;
 	margin: 0px;
 	padding: 0px;


### PR DESCRIPTION
I've investigated the `display: block` usages, and looks that removing them breaks nothing in module.
