### PR TITLE
avoids potential exception if result of childNodes() is undefined

### DIFF
--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -707,7 +707,8 @@
                             selectedElementScope.moved = selectedElementScope.$dragInfo.moveTo(targetNode.$parentNodesScope, targetNode.siblings(), (targetNode.index() + 1 + index));
                           });
                         } else {
-                          var firstChild = (targetNode.childNodes().length > 0) ? targetNode.childNodes()[0] : undefined;
+                          var childNodes = targetNode.childNodes();
+                          var firstChild = (childNodes && childNodes.length > 0) ? childNodes[0] : undefined;
                           var firstChildOffset = (angular.isDefined(firstChild)) ? $uiTreeHelper.offset(firstChild.$element) : undefined;
 
                           var firstChildChildsHeight = (angular.isDefined(firstChild) && firstChild.hasChild()) ? $uiTreeHelper.offset(firstChild.$childNodesScope.$element).height : 0;


### PR DESCRIPTION
this avoids the following exception

![](http://content.screencast.com/users/chiller/folders/Jing/media/d78cb41d-b1dd-4957-acde-6ec41bf864ea/00000125.png)

I'm not sure what causes this exactly.
