### PR TITLE
Bug fixes in Master 

### DIFF
--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -707,7 +707,7 @@
                             selectedElementScope.moved = selectedElementScope.$dragInfo.moveTo(targetNode.$parentNodesScope, targetNode.siblings(), (targetNode.index() + 1 + index));
                           });
                         } else {
-                          var firstChild = (targetNode.childNodes().length > 0) ? targetNode.childNodes()[0] : undefined;
+                          var firstChild = (targetNode.childNodesCount() > 0) ? targetNode.childNodes()[0] : undefined;
                           var firstChildOffset = (angular.isDefined(firstChild)) ? $uiTreeHelper.offset(firstChild.$element) : undefined;
 
                           var firstChildChildsHeight = (angular.isDefined(firstChild) && firstChild.hasChild()) ? $uiTreeHelper.offset(firstChild.$childNodesScope.$element).height : 0;
@@ -722,7 +722,14 @@
                             angular.forEach(scope.$treeScope.$selecteds, function(selectedElement, index) {
                               var selectedElementScope = angular.element(selectedElement).scope();
 
-                              selectedElementScope.moved = selectedElementScope.$dragInfo.moveTo(targetNode.$childNodesScope, targetNode.childNodes(), index);
+                              var target = targetNode;
+                              if (!target.$childNodesScope){
+                                while (typeof(target.$childNodesScope) === "undefined"){
+                                  target = target.$parent;
+                                }
+                              }
+
+                              selectedElementScope.moved = selectedElementScope.$dragInfo.moveTo(target.$childNodesScope, target.childNodes(), index);
                             });
                           }
                         }
@@ -860,7 +867,7 @@
               angular.element($document).unbind('touchmove', dragMoveEvent); // Mobile
               angular.element($document).unbind('mouseup', dragEndEvent);
               angular.element($document).unbind('mousemove', dragMoveEvent);
-              angular.element($window.document.body).unbind('mouseleave', dragCancelEvent);
+              angular.element($document).unbind('mouseleave', dragCancelEvent);
             };
 
             var dragStartEvent = function(e) {
@@ -926,12 +933,12 @@
 
             var unbind = function() {
               dragEnd();
-              angular.element($window.document.body).unbind('keydown').unbind('keyup');
+              angular.element($document).unbind('keydown').unbind('keyup');
             };
 
             bindDrag();
 
-            angular.element($window.document.body).bind("keydown", function(e) {
+            angular.element($document).bind("keydown", function(e) {
               if (e.keyCode === scope.$treeScope.cancelKey) {
                 dragCancelEvent(e);
               }
@@ -967,7 +974,7 @@
               }
             });
 
-            angular.element($window.document.body).bind("keyup", function(e) {
+            angular.element($document).bind("keyup", function(e) {
               if (angular.isDefined(scope.$treeScope.lockXKey)) {
                 if (e.keyCode === scope.$treeScope.lockXKey) {
                   scope.$treeScope.$apply(function() {


### PR DESCRIPTION
There were some problems with master. 

In file, uiTreeNode.js.

Line 710 - problem when the list is null or undefined - cannot call .length.  So i updated it to use the protected method to find the childNode count without throwing up. :)

Line 725 - this i am unsure about, and would like some dialog.  Problem was that when callbacks.accept is called, because move == true, we have undefined $childNodesScope and childNodes().  So what I am doing is going up the heriarchy so that we can get the parent that contains the children.  This has stopped causing JS exceptions from being thrown but not the right fix i don't think.

Line 870, 936, 941, and 977(line #'s all reflect the update to 725) all have been modified so that we use the standard $document to bind to.  This is really just to ensure we remain consistent in binding usage. 

NOTE: we will need to merge PR #256 so that the build happens successfully.

Please advise as to how to proceed with modifications on line 725.  Also, as of now the resorting functionality is completely broken - so I am not going to use it as of now.  The accept() callback does return true but we never get a drop() callback to happen and the placeholders never present themselves properly.  I had to use master because of a memory leak that was causing problems that has been fixed but not released. 

Thanks for the cool project and please let me know what i can do to get this all working again!
Nick
