### PR TITLE
Fixing #202 and correcting functionality drag-delay

### DIFF
--- a/dist/angular-ui-tree.js
+++ b/dist/angular-ui-tree.js
@@ -1198,8 +1198,10 @@
               element.bind('touchstart mousedown', function (e) {
                 dragDelaying = true;
                 dragStarted = false;
-                dragStartEvent(e);
-                dragTimer = $timeout(function(){dragDelaying = false;}, scope.dragDelay);
+                dragTimer = $timeout(function(){
+                  dragDelaying = false;
+                  dragStartEvent(e)
+                }, scope.dragDelay);
               });
               element.bind('touchend touchcancel mouseup',function(){$timeout.cancel(dragTimer);});
             };


### PR DESCRIPTION
Resolves the issue that clickable elements are not firing click event, drag-delay suppose to solve the problem but it was not finished correctly. I have fixed it with this commit.
