### PR TITLE
bower.json fixes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,8 +22,7 @@
     "node"
   ],
   "dependencies": {
-    "angular": ">= 1.2.0",
-    "es5-shim": "2.3.0"
+    "angular": ">= 1.2.0"
   },
   "devDependencies": {
     "angular": ">= 1.2.0",


### PR DESCRIPTION
It's application developer reponsibility to add or not ES5-shim, based on targetted browser for his own application. 

So it should not be listed in dependencies, has it will always grab the dependency using build tools like wiredep.

Also, the main CSS file should be provided unminified, like JS file. (Still to be done)