### PR TITLE
fixed TypeError: Cannot read property '$modelValue' of null, on line 645...

### DIFF
--- a/dist/angular-ui-tree.js
+++ b/dist/angular-ui-tree.js
@@ -641,8 +641,8 @@
             scope.$emptyElm.addClass(config.emptyTreeClass);
           }
 
-          scope.$watch('$nodesScope.$modelValue.length', function() {
-            if (scope.$nodesScope.$modelValue) {
+          scope.$watch('$nodesScope.$modelValue.length', function(val) {
+            if((typeof val) != 'undefined' && scope.$nodesScope.$modelValue){
               scope.resetEmptyElement();
             }
           }, true);


### PR DESCRIPTION
..., angular-ui-tree.js. This happens when the $nodeScope.$modelValue is undefined or null.