### PR TITLE
Revert "Bug fix to Duplicate Key in Repeater thrown by angular"

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Injecting `ui.tree`, `ui-tree-nodes`, `ui-tree-node`, `ui-tree-handle` to your h
     {{node.title}}
   </div>
   <ol ui-tree-nodes="" ng-model="node.nodes">
-    <li ng-repeat="node in node.nodes track by $index" ui-tree-node ng-include="'nodes_renderer.html'">
+    <li ng-repeat="node in node.nodes" ui-tree-node ng-include="'nodes_renderer.html'">
     </li>
   </ol>
 </script>


### PR DESCRIPTION
Hi Jim, you may want to revert my pull request. I found out yesterday that your old way is correct. My patch will solve the duplicated key error but IT WILL CAUSE SEVERAL WEIRD BEHAVIORS. For instance, when you drag a node to somewhere,  the accepting parent node will not accept it correctly. So please do revert my pull request. 
 
Later I found out the duplicated key error for unlimited nesting originated from the new child node, which had the same hashKey as the parent node. Specifically, below is a short version of my newSubItem

$scope.newSubItem = function (scope) {
     var nodeData = scope.$modelValue;
   // this part copied the parent hashKey into child and was causing the problem
     var childNode = JSON.parse(JSON.stringify(nodeData)); 
      childNode.title = "blablah";
   nodeData.nodes.push(childNode)
}