### PR TITLE
Git should checkout JS files with LF line endings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# JSCS requires LF line endings
+*.js text eol=lf


### PR DESCRIPTION
I use Windows OS. And my git checkout *.js files with CRLF line endings. But JSCS requires LF line ending. For this reason, I could not build the project.
It is a fix for this problem.