### PR TITLE
Added usage example to collapseAll method in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ If a tree is empty, there will be an empty place hoder which is used to drop nod
 ##### collapseAll()
 Collapse all it's child nodes.
 
+Usage: ```angular.element('[ui-tree]').$broadcast('collapseAll');```
+
 ##### expandAll()
 Expand all it's child nodes.
 


### PR DESCRIPTION
I tried using the collapseAll method and only when looking in the demo I saw it should be used using $broadcast. Thought i'd add it to the docs...