### PR TITLE
Corrected attribute name and fixed typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ If you write your own [$callbacks.accept](#accept) method, you have to check `da
 ##### data-drag-delay
 Number of milliseconds a click must be held to start a drag. (default 0)
 
-##### data-empty-place-holder-enabled
-If a tree is empty, there will be an empty place hoder which is used to drop node from other trees by default.
-- `true` (default): display an empty place holder if the tree is empty
-- `false`: do not display an empty place hoder
+##### data-empty-placeholder-enabled
+If a tree is empty, there will be an empty placeholder which is used to drop node from other trees by default.
+- `true` (default): display an empty placeholder if the tree is empty
+- `false`: do not display an empty placeholder
 
 ##### Example 
 - turn on/off drag and drop.


### PR DESCRIPTION
Attribute name 'data-empty-place-holder-enabled' was incorrect and thus had no effect on placeholder appearance, angular-ui-tree expects scope property emptyPlaceholderEnabled, and according to convention the correct name should be 'data-empty-placeholder-enabled'.