### PR TITLE
Fixing severe memory leak

### DIFF
--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -412,12 +412,19 @@
               element.bind('touchend touchcancel mouseup',function(){$timeout.cancel(dragTimer);});
             };
             bindDrag();
-
-            angular.element($window.document.body).bind("keydown", function(e) {
-              if (e.keyCode == 27) {
-                scope.$$apply = false;
-                dragEnd(e);
-              }
+            
+            var keydownHandler = function(e) {
+                  if (e.keyCode == 27) {
+                      scope.$$apply = false;
+                      dragEnd(e);
+                  }
+            };
+            
+            angular.element($window.document.body).bind("keydown", keydownHandler);
+            
+            //unbind handler that retains scope
+            scope.$on('$destroy', function () {
+                  angular.element($window.document.body).unbind("keydown", keydownHandler);
             });
           }
         };


### PR DESCRIPTION
keyup event was retaining scope which was retaining html nodes, cleaning up on $destroy

verified that this fixes memory leak

this article gave me insight into the problem:
http://www.codeproject.com/Articles/882966/Fixing-Memory-Leaks-in-AngularJS-and-other-JavaScr