### PR TITLE
Fix #448 empty-placeholder-enabled does not work

### DIFF
--- a/source/directives/uiTree.js
+++ b/source/directives/uiTree.js
@@ -2,8 +2,8 @@
   'use strict';
 
   angular.module('ui.tree')
-  .directive('uiTree', [ 'treeConfig', '$window',
-    function(treeConfig, $window) {
+  .directive('uiTree', [ 'treeConfig', '$window', '$parse',
+    function(treeConfig, $window, $parse) {
       return {
         restrict: 'A',
         scope: true,
@@ -37,9 +37,13 @@
             }
           });
 
-          scope.$watch(attrs.emptyPlaceHolderEnabled, function(val) {
+          scope.$watch(attrs.emptyPlaceholderEnabled, function(val) {
+            if((typeof val) == "string") {
+              val = $parse(val)(scope);
+            }
             if((typeof val) == "boolean") {
               scope.emptyPlaceHolderEnabled = val;
+              scope.resetEmptyElement();
             }
           });
 


### PR DESCRIPTION
A quick fix for the [data-]empty-placeholder-enabled attribute. It looks like many of the other attributes will be similarly affected, but I don't have time to address them. This may be a breaking change for anyone who is managing to use the attribute in a way that works because I've renamed the attribute to match the documentation.