### PR TITLE
Rename API attribute for toggling the empty placeholder

### DIFF
--- a/source/controllers/treeCtrl.js
+++ b/source/controllers/treeCtrl.js
@@ -14,7 +14,7 @@
         $scope.$callbacks = null;
 
         $scope.dragEnabled = true;
-        $scope.emptyPlaceHolderEnabled = true;
+        $scope.emptyPlaceholderEnabled = true;
         $scope.maxDepth = 0;
         $scope.dragDelay = 0;
         $scope.cloneEnabled = false;
@@ -34,7 +34,7 @@
 
         this.resetEmptyElement = function () {
           if ($scope.$nodesScope.$modelValue.length === 0 &&
-            $scope.emptyPlaceHolderEnabled) {
+            $scope.emptyPlaceholderEnabled) {
             $element.append($scope.$emptyElm);
           } else {
             $scope.$emptyElm.remove();

--- a/source/controllers/treeCtrl.js
+++ b/source/controllers/treeCtrl.js
@@ -32,7 +32,7 @@
           $scope.$emptyElm.remove();
         };
 
-        $scope.resetEmptyElement = function () {
+        this.resetEmptyElement = function () {
           if ($scope.$nodesScope.$modelValue.length === 0 &&
             $scope.emptyPlaceHolderEnabled) {
             $element.append($scope.$emptyElm);
@@ -40,6 +40,8 @@
             $scope.$emptyElm.remove();
           }
         };
+
+        $scope.resetEmptyElement = this.resetEmptyElement;
 
         var collapseOrExpand = function (scope, collapsed) {
           var i, subScope,

--- a/source/directives/uiTree.js
+++ b/source/directives/uiTree.js
@@ -8,7 +8,7 @@
           restrict: 'A',
           scope: true,
           controller: 'TreeController',
-          link: function (scope, element, attrs) {
+          link: function (scope, element, attrs, ctrl) {
             var callbacks = {
               accept: null,
               beforeDrag: null
@@ -26,9 +26,11 @@
             }
 
             scope.$watch('$nodesScope.$modelValue.length', function () {
-              if (scope.$nodesScope.$modelValue) {
-                scope.resetEmptyElement();
+              if (!scope.$nodesScope.$modelValue) {
+                return;
               }
+
+              ctrl.resetEmptyElement();
             }, true);
 
             scope.$watch(attrs.dragEnabled, function (val) {

--- a/source/directives/uiTree.js
+++ b/source/directives/uiTree.js
@@ -39,9 +39,9 @@
               }
             });
 
-            scope.$watch(attrs.emptyPlaceHolderEnabled, function (val) {
+            scope.$watch(attrs.emptyPlaceholderEnabled, function (val) {
               if ((typeof val) == 'boolean') {
-                scope.emptyPlaceHolderEnabled = val;
+                scope.emptyPlaceholderEnabled = val;
               }
             });
 

--- a/source/directives/uiTree.spec.js
+++ b/source/directives/uiTree.spec.js
@@ -44,13 +44,13 @@
     it('should allow enabling / disabling the empty placeholder', function () {
       $scope.enableEmptyPlaceholder = true;
 
-      var element = createElement('<div ui-tree empty-place-holder-enabled="enableEmptyPlaceholder"><div ui-tree-nodes="" ng-model="items"></div></div>');
-      expect(element.scope().emptyPlaceHolderEnabled).toEqual(true);
+      var element = createElement('<div ui-tree empty-placeholder-enabled="enableEmptyPlaceholder"><div ui-tree-nodes="" ng-model="items"></div></div>');
+      expect(element.scope().emptyPlaceholderEnabled).toEqual(true);
 
       $scope.enableEmptyPlaceholder = false;
       $scope.$digest();
 
-      expect(element.scope().emptyPlaceHolderEnabled).toEqual(false);
+      expect(element.scope().emptyPlaceholderEnabled).toEqual(false);
     });
 
     it('should allow enabling / disabling dropping nodes', function () {

--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -113,11 +113,11 @@
               if (tagName.toLowerCase() === 'tr') {
                 placeElm = angular.element($window.document.createElement(tagName));
                 tdElm = angular.element($window.document.createElement('td'))
-                  .addClass(config.placeHolderClass);
+                  .addClass(config.placeholderClass);
                 placeElm.append(tdElm);
               } else {
                 placeElm = angular.element($window.document.createElement(tagName))
-                  .addClass(config.placeHolderClass);
+                  .addClass(config.placeholderClass);
               }
               hiddenPlaceElm = angular.element($window.document.createElement(tagName));
               if (config.hiddenClass) {

--- a/source/main.js
+++ b/source/main.js
@@ -14,7 +14,7 @@
       nodesClass: 'angular-ui-tree-nodes',
       nodeClass: 'angular-ui-tree-node',
       handleClass: 'angular-ui-tree-handle',
-      placeHolderClass: 'angular-ui-tree-placeholder',
+      placeholderClass: 'angular-ui-tree-placeholder',
       dragClass: 'angular-ui-tree-drag',
       dragThreshold: 3,
       levelThreshold: 30


### PR DESCRIPTION
It seems that the functionality for toggling the empty placeholder is working correctly, but the documentation is incorrect. Because the property name is emptyPlaceHolderEnabled, the attribute should be `empty-place-holder-enabled`.

However, as `empty-placeholder-enabled` makes more sense, the API has been updated to reflect this.

Big thanks to @adambowen