### PR TITLE
Restrict to Angular v1.3.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,12 +23,11 @@
     "node"
   ],
   "dependencies": {
-    "angular": ">= 1.2.0"
+    "angular": "~1.3.0"
   },
   "devDependencies": {
-    "angular-mocks": ">= 1.2.0",
-    "angular-route": ">= 1.2.0",
-    "angularfire": "~0.8.2",
+    "angular-mocks": "~1.3.0",
+    "angular-route": "~1.3.0",
     "bootstrap-css": "~3.2.0",
     "jasmine-jquery": "~1.7.0",
     "jquery": "~2.1.1"


### PR DESCRIPTION
This is in order to prevent dependency conflicts with v1.4.x, which is untested with the Tree component.