### PR TITLE
Add deployment task for the website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ node_modules
 
 examples/bower_components
 examples/source
+
+# Other #
+#########
+.publish

--- a/README.md
+++ b/README.md
@@ -459,3 +459,8 @@ This will generate non-minified and minified JavaScript files in the `dist` dire
 You can run the unit test using a separate task.
 
     $ gulp test
+
+####Deploy examples
+
+    $ gulp deploy
+    

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,10 @@ gulp.task('build', ['clean'], function () {
   return gulp.start('styles', 'jscs', 'jshint', 'uglify', 'styles', 'test');
 });
 
+gulp.task('deploy', function () {
+  return gulp.start('website');
+});
+
 gulp.task('serve', function () {
   return gulp.start('connect', 'watch', 'open');
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gulp-clean": "^0.3.1",
     "gulp-concat": "^2.4.3",
     "gulp-connect": "^2.2.0",
+    "gulp-gh-pages": "^0.5.2",
     "gulp-jscs": "^1.4.0",
     "gulp-jshint": "^1.9.0",
     "gulp-load-plugins": "^0.8.0",

--- a/tasks/website.js
+++ b/tasks/website.js
@@ -3,7 +3,11 @@
 module.exports = function (gulp, $) {
 
   gulp.task('website', function () {
-    return gulp.src('examples/**/*')
+    return gulp.src([
+      'examples/**/*',
+      '!examples/source',
+      'source'
+    ])
       .pipe($.ghPages({
         branch: 'test-website-deployment'
       }));

--- a/tasks/website.js
+++ b/tasks/website.js
@@ -8,8 +8,6 @@ module.exports = function (gulp, $) {
       '!examples/source',
       'source'
     ])
-      .pipe($.ghPages({
-        branch: 'test-website-deployment'
-      }));
+      .pipe($.ghPages());
   });
 };

--- a/tasks/website.js
+++ b/tasks/website.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function (gulp, $) {
+
+  gulp.task('website', function () {
+    return gulp.src('examples/**/*')
+      .pipe($.ghPages({
+        branch: 'test-website-deployment'
+      }));
+  });
+};


### PR DESCRIPTION
Simplify updating the website by adding the `$ gulp deploy` task to publish the updates.
The source of the website is based in the `/examples` directory.