### PR TITLE
Fix position detection on touch devices when using jQuery

### DIFF
--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -256,9 +256,7 @@
                 }
 
                 // move horizontal
-                var hMove = false;
                 if (pos.dirAx && pos.distAxX >= config.levelThreshold) {
-                  hMove = true;
                   pos.distAxX = 0;
 
                   // increase horizontal level if previous sibling exists and is not collapsed
@@ -314,7 +312,7 @@
                 }
 
                 // move vertical
-                if (!pos.dirAx || hMove) {
+                if (!pos.dirAx) {
                   // check it's new position
                   targetNode = targetElm.scope();
                   isEmpty = false;

--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -256,7 +256,9 @@
                 }
 
                 // move horizontal
+                var hMove = false;
                 if (pos.dirAx && pos.distAxX >= config.levelThreshold) {
+                  hMove = true;
                   pos.distAxX = 0;
 
                   // increase horizontal level if previous sibling exists and is not collapsed
@@ -312,7 +314,7 @@
                 }
 
                 // move vertical
-                if (!pos.dirAx) {
+                if (!pos.dirAx || hMove) {
                   // check it's new position
                   targetNode = targetElm.scope();
                   isEmpty = false;

--- a/source/services/helper.js
+++ b/source/services/helper.js
@@ -244,23 +244,29 @@
            */
           positionStarted: function (e, target) {
             var pos = {};
-            pos.offsetX = e.pageX - this.offset(target).left;
-            pos.offsetY = e.pageY - this.offset(target).top;
-            pos.startX = pos.lastX = e.pageX;
-            pos.startY = pos.lastY = e.pageY;
+            var pageX = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageX : e.pageX;
+            var pageY = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageY : e.pageY;
+
+            pos.offsetX = pageX - this.offset(target).left;
+            pos.offsetY = pageY - this.offset(target).top;
+            pos.startX = pos.lastX = pageX;
+            pos.startY = pos.lastY = pageY;
             pos.nowX = pos.nowY = pos.distX = pos.distY = pos.dirAx = 0;
             pos.dirX = pos.dirY = pos.lastDirX = pos.lastDirY = pos.distAxX = pos.distAxY = 0;
             return pos;
           },
 
           positionMoved: function (e, pos, firstMoving) {
+            var pageX = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageX : e.pageX;
+              var pageY = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageY : e.pageY;
+            
             // mouse position last events
             pos.lastX = pos.nowX;
             pos.lastY = pos.nowY;
 
             // mouse position this events
-            pos.nowX = e.pageX;
-            pos.nowY = e.pageY;
+            pos.nowX = pageX;
+            pos.nowY = pageY;
 
             // distance mouse moved between events
             pos.distX = pos.nowX - pos.lastX;

--- a/source/services/helper.js
+++ b/source/services/helper.js
@@ -244,9 +244,14 @@
            */
           positionStarted: function (e, target) {
             var pos = {},
-            pageX = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageX : e.pageX,
-            pageY = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageY : e.pageY;
-
+            pageX = e.pageX,
+            pageY = e.pageY;
+            
+            if (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) {
+              pageX = e.originalEvent.touches[0].pageX;
+              pageY = e.originalEvent.touches[0].pageY;
+            }
+            
             pos.offsetX = pageX - this.offset(target).left;
             pos.offsetY = pageY - this.offset(target).top;
             pos.startX = pos.lastX = pageX;
@@ -257,8 +262,13 @@
           },
 
           positionMoved: function (e, pos, firstMoving) {
-            var pageX = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageX : e.pageX,
-            pageY = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageY : e.pageY;
+            var pageX = e.pageX,
+            pageY = e.pageY;
+            
+            if (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) {
+              pageX = e.originalEvent.touches[0].pageX;
+              pageY = e.originalEvent.touches[0].pageY;
+            }
             
             // mouse position last events
             pos.lastX = pos.nowX;

--- a/source/services/helper.js
+++ b/source/services/helper.js
@@ -243,9 +243,9 @@
            * @returns {Object} Object with properties offsetX, offsetY, startX, startY, nowX and dirX.
            */
           positionStarted: function (e, target) {
-            var pos = {};
-            var pageX = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageX : e.pageX;
-            var pageY = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageY : e.pageY;
+            var pos = {},
+            pageX = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageX : e.pageX,
+            pageY = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageY : e.pageY;
 
             pos.offsetX = pageX - this.offset(target).left;
             pos.offsetY = pageY - this.offset(target).top;
@@ -257,8 +257,8 @@
           },
 
           positionMoved: function (e, pos, firstMoving) {
-            var pageX = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageX : e.pageX;
-            var pageY = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageY : e.pageY;
+            var pageX = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageX : e.pageX,
+            pageY = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageY : e.pageY;
             
             // mouse position last events
             pos.lastX = pos.nowX;

--- a/source/services/helper.js
+++ b/source/services/helper.js
@@ -258,7 +258,7 @@
 
           positionMoved: function (e, pos, firstMoving) {
             var pageX = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageX : e.pageX;
-              var pageY = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageY : e.pageY;
+            var pageY = (e.originalEvent && e.originalEvent.touches && (e.originalEvent.touches.length > 0)) ? e.originalEvent.touches[0].pageY : e.pageY;
             
             // mouse position last events
             pos.lastX = pos.nowX;


### PR DESCRIPTION
In order to create some kind of trash can like behavior for two connected trees I need to evaluate the drag/move position in the dragStop event. On touch devices this doesn't work because most values of the pos-object are NaN or undefined. Please review the few changed lines of code in 'helper.js'.
Could these changes be merged into 2.8.0? 