### PR TITLE
Added code to handle confirmDrop callback

### DIFF
--- a/source/directives/uiTree.js
+++ b/source/directives/uiTree.js
@@ -106,6 +106,10 @@
 
             };
 
+            callbacks.confirmDrop = function (event) { 
+              
+            };
+
             scope.$watch(attrs.uiTree, function (newVal, oldVal) {
               angular.forEach(newVal, function (value, key) {
                 if (callbacks[key]) {

--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -382,8 +382,10 @@
               e.preventDefault();
 
               if (dragElm) {
+                var needConfirmation = false;
+
                 scope.$treeScope.$apply(function () {
-                  scope.$treeScope.$callbacks.beforeDrop(dragInfo.eventArgs(elements, pos));
+                  needConfirmation = scope.$treeScope.$callbacks.beforeDrop(dragInfo.eventArgs(elements, pos));
                 });
                 // roll back elements changed
                 hiddenPlaceElm.replaceWith(scope.$element);
@@ -391,19 +393,47 @@
 
                 dragElm.remove();
                 dragElm = null;
-                if (scope.$$apply) {
-                  scope.$treeScope.$apply(function () {
-                    dragInfo.apply();
-                    scope.$treeScope.$callbacks.dropped(dragInfo.eventArgs(elements, pos));
-                  });
+                if (needConfirmation) {
+                    scope.$treeScope.$callbacks.confirmationDialog(dragInfo.eventArgs(elements, pos))
+                    .then(function (value) {
+                        // We do not need the scope in the dropped function
+                        // The previous change had no '$treeScope.'. 
+                        // But it was introduced as a correction in line 956 & 962 for v2.5.0 inside the
+                        // 'scope.$treeScope.$apply(function () {})'
+                        // It therefore seems reasonable to introduce it here also.
+                        // The previous change did have the following comment //.$treeScope. 
+                        // Why, I am uncertain about
+                        scope.$treeScope.$evalAsync(function () { 
+                            dragInfo.apply();
+                            scope.$treeScope.$callbacks.dropped(dragInfo.eventArgs(elements, pos));
+                            scope.$treeScope.$callbacks.dragStop(dragInfo.eventArgs(elements, pos));
+                            scope.$$apply = false;
+                            dragInfo = null;
+                        });
+                    })
+                    .catch(function (value) {
+                        scope.$treeScope.$evalAsync(function () { //$treeScope.
+                            bindDrag();
+                            scope.$treeScope.$callbacks.dragStop(dragInfo.eventArgs(elements, pos));
+                            scope.$$apply = false;
+                            dragInfo = null;
+                        });
+                    });
                 } else {
-                  bindDrag();
+                    if (scope.$$apply) {
+                        scope.$treeScope.$apply(function () {
+                            dragInfo.apply();
+                            scope.$treeScope.$callbacks.dropped(dragInfo.eventArgs(elements, pos));
+                        });
+                    } else {
+                        bindDrag();
+                    }
+                    scope.$treeScope.$apply(function () {
+                        scope.$treeScope.$callbacks.dragStop(dragInfo.eventArgs(elements, pos));
+                    });
+                    scope.$$apply = false;
+                    dragInfo = null;
                 }
-                scope.$treeScope.$apply(function () {
-                  scope.$treeScope.$callbacks.dragStop(dragInfo.eventArgs(elements, pos));
-                });
-                scope.$$apply = false;
-                dragInfo = null;
 
               }
 

--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -394,7 +394,7 @@
                 dragElm.remove();
                 dragElm = null;
                 if (needConfirmation) {
-                    scope.$treeScope.$callbacks.confirmationDialog(dragInfo.eventArgs(elements, pos))
+                    scope.$treeScope.$callbacks.confirmDrop(dragInfo.eventArgs(elements, pos))
                     .then(function (value) {
                         // We do not need the scope in the dropped function
                         // The previous change had no '$treeScope.'. 


### PR DESCRIPTION
-  Important comment: This branch is linked to #555 "Added default confirmationDialog callback". I probably made a mistake when I created the branch, but I could not see how I could make changes to two files in the same branch. If somebody knows how to combine the two branches, please let me know.

These two branches implement the change that I described in
angular-ui-tree#262
but never got around to implement in the github code. I have been running the change locally for almost a year and it works nicely. It has been tested on 2.5.0

Should be backwards compatible.

--Morten