### PR TITLE
Fix crashing $nodesScope.$modelValue.length watch

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "jasmine": true,
   "bitwise": true,
   "immed": true,
   "newcap": true,

--- a/source/directives/uiTree.js
+++ b/source/directives/uiTree.js
@@ -25,8 +25,8 @@
               scope.$emptyElm.addClass(config.emptyTreeClass);
             }
 
-            scope.$watch('$nodesScope.$modelValue.length', function () {
-              if (!scope.$nodesScope.$modelValue) {
+            scope.$watch('$nodesScope.$modelValue.length', function (val) {
+              if (!angular.isNumber(val)) {
                 return;
               }
 

--- a/source/directives/uiTree.spec.js
+++ b/source/directives/uiTree.spec.js
@@ -108,6 +108,29 @@
 
       expect(element.scope().dragDelay).toEqual(84);
     });
+
+    describe('$nodesScope', function () {
+      var controller;
+
+      beforeEach(function () {
+        $scope.items.push("item1");
+        createElement();
+        controller = element.controller("uiTree");
+        spyOn(controller, 'resetEmptyElement');
+      });
+
+      it('should reset empty elements', function () {
+        $scope.items.pop();
+        $scope.$digest();
+        expect(controller.resetEmptyElement).toHaveBeenCalled();
+      });
+
+      it('should not attempt to reset elements without a $nodesScope', function () {
+        element.scope().$nodesScope = null;
+        $scope.$digest();
+        expect(controller.resetEmptyElement).not.toHaveBeenCalled();
+      });
+    });
   });
 
 }());

--- a/source/directives/uiTree.spec.js
+++ b/source/directives/uiTree.spec.js
@@ -113,9 +113,9 @@
       var controller;
 
       beforeEach(function () {
-        $scope.items.push("item1");
+        $scope.items.push('item1');
         createElement();
-        controller = element.controller("uiTree");
+        controller = element.controller('uiTree');
         spyOn(controller, 'resetEmptyElement');
       });
 


### PR DESCRIPTION
Ensure that the `uiTree` directive's `$nodesScope.$modelValue.length` watch returns a number. This fixes an issue where $nodeScope will sometimes become undefined if the underlying data structure is modified outside of angular-ui-tree. This would result in a `TypeError: Cannot read property '$modelValue' of
null`.