### PR TITLE
Fix placeholder for tables

### DIFF
--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -35,7 +35,8 @@
               dragDelay,
               bindDrag,
               keydownHandler,
-              outOfBounds;
+              outOfBounds,
+              i;
             angular.extend(config, treeConfig);
             if (config.nodeClass) {
               element.addClass(config.nodeClass);
@@ -116,10 +117,12 @@
               tagName = scope.$element.prop('tagName');
 
               if (tagName.toLowerCase() === 'tr') {
-                placeElm = angular.element($window.document.createElement(tagName));
-                tdElm = angular.element($window.document.createElement('td'))
+                placeElm = angular.element($window.document.createElement(tagName))
                   .addClass(config.placeholderClass);
-                placeElm.append(tdElm);
+                for (i = 0; i < scope.$element[0].children.length; i++) {
+                  tdElm = angular.element($window.document.createElement('td'));
+                  placeElm.append(tdElm);
+                }
               } else {
                 placeElm = angular.element($window.document.createElement(tagName))
                   .addClass(config.placeholderClass);
@@ -338,7 +341,8 @@
                   }
 
                   // Show the placeholder if it was hidden for nodrop-enabled and this is a new tree
-                  if (targetNode.$treeScope && !targetNode.$parent.nodropEnabled && !targetNode.$treeScope.nodropEnabled) {
+                  if (targetNode.$treeScope && !targetNode.$parent.nodropEnabled
+                    && !targetNode.$treeScope.nodropEnabled && placeElm.prop('tagName').toLowerCase() !== 'tr') {
                     placeElm.css('display', 'block');
                   }
 


### PR DESCRIPTION
This PR should fix various problems I found while applying ui-tree to a table. In particular I found that:

- Only one`<td>` tag was created into a `<tr>` placeholder. This creates all sorts of problems with the layout of the rest of the table. Solution: add the same number of `<td>` elements of the original element.
- The `display: block` property applied to a `tr` element messes up the layout of the whole table as well. That's normal, because the `display` property of a table row should just be `table-row`. Solution: don't apply the display property if the element is a `tr`