### PR TITLE
Reset placeholder display attribute instead of changing it to block

### DIFF
--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -339,7 +339,7 @@
 
                   // Show the placeholder if it was hidden for nodrop-enabled and this is a new tree
                   if (targetNode.$treeScope && !targetNode.$parent.nodropEnabled && !targetNode.$treeScope.nodropEnabled) {
-                    placeElm.css('display', 'block');
+                    placeElm.css('display', '');
                   }
 
                   if (targetNode.$type == 'uiTree' && targetNode.dragEnabled) {


### PR DESCRIPTION
Reset placeholder css display attribute, so it resets to whatever the placeholder class display attribute was set to.

In case someone is using a custom placeholder class this can unexpectedly change the css, for example when display is set to 'block-inline';

Pull request https://github.com/angular-ui-tree/angular-ui-tree/pull/525 added this behavior.