### PR TITLE
Feature: Ability to change whether nodes should be collapsed or expanded by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,21 @@ Check if the current node is a child of the target node.
 Use the `ui-tree-handle` to specify an element used to drag the object. 
 If you don't add a `ui-tree-handle` for a node, the entire node can be dragged.
 
+## Runtime Configuration
+Use the `treeConfig` service to configure the tree defaults at runtime.
+With this you can customize the classes applied to various tree elements
+(`treeClass`, `emptyTreeClass`, `hiddenClass`, `nodesClass`, `handleClass`,
+`placeholderClass`, `dragClass`).
+
+In addition, you can modify whether nodes are collapsed by default
+(`defaultCollapsed`: default false). For example:
+
+```js
+module.config(function(treeConfig) {
+  treeConfig.defaultCollapsed = true; // collapse nodes by default
+});
+```
+
 ## NgModules Link
 
 [Give us a like on ngmodules](http://ngmodules.org/modules/angular-ui-tree)

--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -42,7 +42,7 @@
             }
             scope.init(controllersArr);
 
-            scope.collapsed = !!UiTreeHelper.getNodeAttribute(scope, 'collapsed');
+            scope.collapsed = !!UiTreeHelper.getNodeAttribute(scope, 'collapsed') || treeConfig.defaultCollapsed;
             scope.sourceOnly = scope.nodropEnabled || scope.$treeScope.nodropEnabled;
 
             scope.$watch(attrs.collapsed, function (val) {

--- a/source/main.js
+++ b/source/main.js
@@ -17,7 +17,8 @@
       placeholderClass: 'angular-ui-tree-placeholder',
       dragClass: 'angular-ui-tree-drag',
       dragThreshold: 3,
-      levelThreshold: 30
+      levelThreshold: 30,
+      defaultCollapsed: false
     });
 
 })();


### PR DESCRIPTION
## Overview
This changes the functionality of nodes so that whether they are collapsed or not by default is configurable. Currently, all nodes are expanded by default. This behavior cannot be changed, which can be limiting.

## Backwards Compatibility
Because ```defaultCollapsed``` defaults to ```false```, behavior after this change should be consistent with the previous behavior.

## Usage Example
```javascript
module.config(function(treeConfig) {
    treeConfig.defaultCollapsed = true;
});
```