### PR TITLE
Setup Coveralls integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ examples/source
 #########
 .tmp
 .publish
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ before_script:
 script:
   - npm test
 
+after_success:
+  - npm run coveralls
+
 notifications:
   - email: false
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,12 +26,14 @@ module.exports = function(config) {
 
     plugins: [
       'karma-phantomjs-launcher',
-      'karma-jasmine'
+      'karma-jasmine',
+      'karma-coverage'
     ],
 
     // generate js files from html templates to expose them during testing
     preprocessors: {
-      '**/*.html': 'ng-html2js'
+      '**/*.html': 'ng-html2js',
+      'source/**/!(*spec).js': ['coverage']
     },
 
     // https://github.com/karma-runner/karma-ng-html2js-preprocessor#configuration
@@ -48,7 +50,12 @@ module.exports = function(config) {
     logLevel: config.LOG_INFO,
 
     port: 9876,
-    reporters: 'dots',
-    singleRun: true
+    reporters: ['dots', 'coverage'],
+    singleRun: true,
+
+    coverageReporter: {
+      type: 'lcov',
+      dir: 'coverage'
+    }
   });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -54,8 +54,11 @@ module.exports = function(config) {
     singleRun: true,
 
     coverageReporter: {
-      type: 'lcov',
-      dir: 'coverage'
+      dir: 'coverage',
+      reporters: [{
+        type: 'lcov',
+        subdir: 'lcov'
+      }]
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   },
   "scripts": {
     "test": "gulp build && gulp test:e2e",
-    "coveralls": "cat ./coverage/lcov.info | coveralls"
+    "coveralls": "cat ./coverage/lcov/lcov.info | coveralls"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gulp-uglify": "^1.1.0",
     "jshint-stylish": "^1.0.0",
     "karma": "^0.12.24",
+    "karma-coverage": "^0.5.3",
     "karma-firefox-launcher": "^0.1.3",
     "karma-jasmine": "~0.1.0",
     "karma-phantomjs-launcher": "^0.1.4",
@@ -39,6 +40,7 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "test": "gulp build && gulp test:e2e"
+    "test": "gulp build && gulp test:e2e",
+    "coveralls": "cat ./coverage/lcov.info | coveralls"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "index.js",
   "devDependencies": {
     "connect-livereload": "^0.5.2",
+    "coveralls": "^2.11.4",
     "del": "^1.2.0",
     "gulp": "^3.9.0",
     "gulp-clean": "^0.3.1",


### PR DESCRIPTION
Add test coverage details to the project using http://coveralls.io/

Thanks to @dsernst for writing http://dsernst.com/2015/09/02/node--mocha--travis--istanbul--coveralls-unit-tests--coverage-for-your-open-source-project/