### PR TITLE
Fix accept() to check $treeScope.nodropEnabled

### DIFF
--- a/source/directives/uiTree.js
+++ b/source/directives/uiTree.js
@@ -94,7 +94,7 @@
             // and the 'max-depth' attribute in `ui-tree` or `ui-tree-nodes`.
             // the method can be overrided
             callbacks.accept = function (sourceNodeScope, destNodesScope, destIndex) {
-              return !(destNodesScope.nodropEnabled || destNodesScope.outOfDepth(sourceNodeScope));
+              return !(destNodesScope.nodropEnabled || destNodesScope.$treeScope.nodropEnabled || destNodesScope.outOfDepth(sourceNodeScope));
             };
 
             callbacks.beforeDrag = function (sourceNodeScope) {


### PR DESCRIPTION
The default accept() callback is only checked if nodropEnabled was set on
the dest scope, but not on the scope of the whole tree.
The examples and the doc both apply nodropEnabled to the ui-tree only.

This breaks the [clone example](https://angular-ui-tree.github.io/angular-ui-tree/#/cloning), if a node is selected from Tree 1, dragged over to Tree 2 (but not dropped), and then dragged back to Tree 1, a place holder will be shown for it.