### PR TITLE
Fix #680 (drag-drop not working if beforeDrop is not implemented)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Same as [Parameters](#eventParam) of dropped.
 
 - **Resolved Promise** or **truthy**: Allow the node to be dropped
 
-- **Rejected Promise** or **falsy**: Disallow the node drop and return the dragged node to its original position
+- **Rejected Promise** or **false**: Disallow the node drop and return the dragged node to its original position
 
 ### ui-tree-nodes
 `ui-tree-nodes` is the container of nodes. 

--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -413,9 +413,9 @@
 
               scope.$treeScope.$apply(function () {
                 $q.when(scope.$treeScope.$callbacks.beforeDrop(dragEventArgs))
-                    // promise resolved (or callback returned truthy)
+                    // promise resolved (or callback didn't return false)
                     .then(function (allowDrop) {
-                      if (allowDrop && scope.$$allowNodeDrop && !outOfBounds) { // node drop accepted)
+                      if (allowDrop !== false && scope.$$allowNodeDrop && !outOfBounds) { // node drop accepted)
                         dragInfo.apply();
                         // fire the dropped callback only if the move was successful
                         scope.$treeScope.$callbacks.dropped(dragEventArgs);


### PR DESCRIPTION
Fixes issue where *not* implementing beforeDrop in apps caused drop events to be rejected. This occurred because the event handler in ui-tree-node was checking for a truthy `allowDrop` value, however, if the callback was not implemented elsewhere, `allowDrop` was `undefined`, which is falsy and was being handled as a rejected drop.