### PR TITLE
Allow drag-drop on empty tree

### DIFF
--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -329,7 +329,8 @@
                               !UiTreeHelper.elementIsTreeNode(targetElm) &&
                               !UiTreeHelper.elementIsTreeNodes(targetElm) &&
                               !UiTreeHelper.elementIsTree(targetElm) &&
-                              !UiTreeHelper.elementIsPlaceholder(targetElm);
+                              !UiTreeHelper.elementIsPlaceholder(targetElm) &&
+                              !UiTreeHelper.elementIsEmptyTree(targetElm);
 
                 // Detect out of bounds condition, update drop target display, and prevent drop
                 if (outOfBounds) {
@@ -377,6 +378,8 @@
                 if (!pos.dirAx) {
                   if (UiTreeHelper.elementIsTree(targetElm)) {
                     targetNode = targetElm.controller('uiTree').scope;
+                  } else if (UiTreeHelper.elementIsEmptyTree(targetElm)) {
+                    targetNode = targetElm.controller('uiTree').scope;
                   } else if (UiTreeHelper.elementIsTreeNodeHandle(targetElm)) {
                     targetNode = targetElm.controller('uiTreeHandle').scope;
                   } else if (UiTreeHelper.elementIsTreeNode(targetElm)) {
@@ -396,8 +399,11 @@
                     return;
                   }
 
-                  // Show the placeholder if it was hidden for nodrop-enabled and this is a new tree
-                  if (targetNode.$treeScope && !targetNode.$parent.nodropEnabled && !targetNode.$treeScope.nodropEnabled) {
+                  // Show the placeholder if it was hidden for nodrop-enabled and this is a new tree (or an empty tree)
+                  if (
+                    (targetNode.$type == 'uiTree'&& !targetNode.nodropEnabled) ||
+                    (targetNode.$treeScope && !targetNode.$treeScope.nodropEnabled && !targetNode.$parent.nodropEnabled)
+                  ) {
                     placeElm.css('display', '');
                   }
 

--- a/source/services/helper.js
+++ b/source/services/helper.js
@@ -320,7 +320,9 @@
           elementIsTreeNode: function (element) {
             return typeof element.attr('ui-tree-node') !== 'undefined';
           },
-
+          elementIsEmptyTree: function (element) {
+            return element.attr('class') == "angular-ui-tree-empty";
+          },
           elementIsTreeNodeHandle: function (element) {
             return typeof element.attr('ui-tree-handle') !== 'undefined';
           },


### PR DESCRIPTION
Added helper function to test for empty tree.
Do NOT mark "out of bounds" when hovering over empty tree.
Correctly set targetElm when hovering over empty tree.
Display placeholder when hovering over empty tree.
