### PR TITLE
Create options do transform model when a node is cloned 

### DIFF
--- a/source/controllers/nodesCtrl.js
+++ b/source/controllers/nodesCtrl.js
@@ -72,7 +72,7 @@
 
         $scope.insertNode = function (index, nodeData) {
           $scope.safeApply(function () {
-            $scope.$modelValue.splice(index, 0, nodeData);
+            $scope.$modelValue.splice(index, 0, $scope.$treeScope.$callbacks.onClone(nodeData));
           });
         };
 

--- a/source/directives/uiTree.js
+++ b/source/directives/uiTree.js
@@ -157,6 +157,10 @@
             callbacks.beforeDrop = function (event) {
 
             };
+            
+            callbacks.onClone = function (data) {
+              return data;
+            };
 
             scope.$watch(attrs.uiTree, function (newVal, oldVal) {
               angular.forEach(newVal, function (value, key) {


### PR DESCRIPTION
This pull make it possible to transform objects when it's cloned from some tree to another.

In cases that the model objects are different, it's possible (and optional) to transform the model to something that the destination can handle.
