### PR TITLE
append dragElm when $rootElement is still document

### DIFF
--- a/dist/angular-ui-tree.js
+++ b/dist/angular-ui-tree.js
@@ -546,8 +546,8 @@
 
   angular.module('ui.tree')
 
-    .directive('uiTreeNode', ['treeConfig', 'UiTreeHelper', '$window', '$document', '$timeout', '$q', '$rootElement', '$compile',
-      function (treeConfig, UiTreeHelper, $window, $document, $timeout, $q, $rootElement, $compile) {
+    .directive('uiTreeNode', ['treeConfig', 'UiTreeHelper', '$window', '$document', '$timeout', '$q', '$rootElement',
+      function (treeConfig, UiTreeHelper, $window, $document, $timeout, $q, $rootElement) {
         return {
           require: ['^uiTreeNodes', '^uiTree'],
           restrict: 'A',
@@ -733,7 +733,7 @@
                 _element = document.body;
               }
 
-              angular.element(_element).append($compile(dragElm)(scope));
+              angular.element(_element).append(dragElm);
 
               dragElm.css({
                 'left': eventObj.pageX - pos.offsetX + 'px',

--- a/dist/angular-ui-tree.js
+++ b/dist/angular-ui-tree.js
@@ -546,8 +546,8 @@
 
   angular.module('ui.tree')
 
-    .directive('uiTreeNode', ['treeConfig', 'UiTreeHelper', '$window', '$document', '$timeout', '$q', '$rootElement',
-      function (treeConfig, UiTreeHelper, $window, $document, $timeout, $q, $rootElement) {
+    .directive('uiTreeNode', ['treeConfig', 'UiTreeHelper', '$window', '$document', '$timeout', '$q', '$rootElement', '$compile',
+      function (treeConfig, UiTreeHelper, $window, $document, $timeout, $q, $rootElement, $compile) {
         return {
           require: ['^uiTreeNodes', '^uiTree'],
           restrict: 'A',
@@ -727,7 +727,13 @@
                 dragElm.append(element);
               }
 
-              $rootElement.append(dragElm);
+              var document = $document[0],
+                  _element = $rootElement[0];
+              if (_element === document || _element === document.documentElement) {
+                _element = document.body;
+              }
+
+              angular.element(_element).append($compile(dragElm)(scope));
 
               dragElm.css({
                 'left': eventObj.pageX - pos.offsetX + 'px',


### PR DESCRIPTION
When $rootElement is document,$rootElement.append(dragElem) may cause an error "TypeError: Cannot read property 'createDocumentFragment' of null"
This commit can fix this problem,I think so.