### PR TITLE
Update angular-ui-tree.js

### DIFF
--- a/dist/angular-ui-tree.js
+++ b/dist/angular-ui-tree.js
@@ -727,7 +727,7 @@
                 dragElm.append(element);
               }
 
-              $rootElement.append(dragElm);
+              $document.find('body').append(dragElm);
 
               dragElm.css({
                 'left': eventObj.pageX - pos.offsetX + 'px',


### PR DESCRIPTION
just changed
$rootElement.append(dragElm);
to
$document.find('body').append(dragElm);

angular.js:13236 TypeError: Cannot read property 'createDocumentFragment' of null
at Function.n.extend.buildFragment (jquery.js:5087)
at n.fn.extend.domManip (jquery.js:5387)
at n.fn.extend.append (jquery.js:5218)
at dragStart (angular-ui-tree.js:730)
at dragStartEvent (angular-ui-tree.js:1044)
at angular-ui-tree.js:1084
at angular.js:18744
at completeOutstandingRequest (angular.js:5804)
at angular.js:6081