### PR TITLE
Add ability to append child nodes by dragging over parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,12 +475,18 @@ With this you can customize the classes applied to various tree elements
 (`treeClass`, `emptyTreeClass`, `hiddenClass`, `nodesClass`, `handleClass`,
 `placeholderClass`, `dragClass`).
 
-In addition, you can modify whether nodes are collapsed by default
-(`defaultCollapsed`: default false). For example:
+In addition, you can modify whether or not nodes are collapsed by default
+(`defaultCollapsed`: default false).
+
+You can also modify whether or not dragging a node over a parent node will insert the node as a child
+(`appendChildOnHover`: default false).
+
+For example:
 
 ```js
 module.config(function(treeConfig) {
   treeConfig.defaultCollapsed = true; // collapse nodes by default
+  treeConfig.appendChildOnHover = true; // append dragged nodes as children by default
 });
 ```
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -34,6 +34,7 @@
           <li><a href="#/table-example">Table example</a></li>
           <li><a href="#/drop-confirmation">Drop confirmation</a></li>
           <li><a href="#/expand-on-hover">Expand parent node on drag hover</a></li>
+          <li><a href="#/append-child-on-hover">Add child to parent node on drag hover</a></li>
         </ol>
       </div>
 
@@ -93,5 +94,6 @@
 <script src="js/table-example.js"></script>
 <script src="js/drop-confirmation.js"></script>
 <script src="js/expand-on-hover.js"></script>
+<script src="js/append-child-on-hover.js"></script>
 </body>
 </html>

--- a/examples/js/app.js
+++ b/examples/js/app.js
@@ -33,10 +33,14 @@
           controller: 'DropConfirmationCtrl',
           templateUrl: 'views/drop-confirmation.html'
         })
-		.when('/expand-on-hover', {
-			controller: 'ExpandOnHoverCtrl',
-			templateUrl: 'views/expand-on-hover.html'
-		})
+        .when('/expand-on-hover', {
+          controller: 'ExpandOnHoverCtrl',
+          templateUrl: 'views/expand-on-hover.html'
+        })
+        .when('/append-child-on-hover', {
+          controller: 'AppendChildOnHoverCtrl',
+          templateUrl: 'views/append-child-on-hover.html'
+        })
         .otherwise({
           redirectTo: '/basic-example'
         });

--- a/examples/js/append-child-on-hover.js
+++ b/examples/js/append-child-on-hover.js
@@ -1,0 +1,92 @@
+(function () {
+  'use strict';
+
+  angular.module('demoApp')
+    .controller('AppendChildOnHoverCtrl', ['$scope', 'treeConfig', function ($scope, treeConfig) {
+      treeConfig.appendChildOnHover = true; // false by default
+
+      $scope.remove = function (scope) {
+        scope.remove();
+      };
+
+      $scope.toggle = function (scope) {
+        scope.toggle();
+      };
+
+      $scope.moveLastToTheBeginning = function () {
+        var a = $scope.data.pop();
+        $scope.data.splice(0, 0, a);
+      };
+
+      $scope.newSubItem = function (scope) {
+        var nodeData = scope.$modelValue;
+        nodeData.nodes.push({
+          id: nodeData.id * 10 + nodeData.nodes.length,
+          title: nodeData.title + '.' + (nodeData.nodes.length + 1),
+          nodes: []
+        });
+      };
+
+      $scope.collapseAll = function () {
+        $scope.$broadcast('angular-ui-tree:collapse-all');
+      };
+
+      $scope.expandAll = function () {
+        $scope.$broadcast('angular-ui-tree:expand-all');
+      };
+
+      $scope.$on("$destroy", function() {
+        treeConfig.appendChildOnHover = false; // revert when user leaves view
+      });
+
+      $scope.data = [{
+        'id': 1,
+        'title': 'node1',
+        'nodes': [
+          {
+            'id': 11,
+            'title': 'node1.1',
+            'nodes': [
+              {
+                'id': 111,
+                'title': 'node1.1.1',
+                'nodes': []
+              }
+            ]
+          },
+          {
+            'id': 12,
+            'title': 'node1.2',
+            'nodes': []
+          }
+        ]
+      }, {
+        'id': 2,
+        'title': 'node2',
+        'nodrop': true, // An arbitrary property to check in custom template for nodrop-enabled
+        'nodes': [
+          {
+            'id': 21,
+            'title': 'node2.1',
+            'nodes': []
+          },
+          {
+            'id': 22,
+            'title': 'node2.2',
+            'nodes': []
+          }
+        ]
+      }, {
+        'id': 3,
+        'title': 'node3',
+        'nodes': [
+          {
+            'id': 31,
+            'title': 'node3.1',
+            'nodes': []
+          }
+        ]
+      }];
+    }]);
+
+}());

--- a/examples/views/append-child-on-hover.html
+++ b/examples/views/append-child-on-hover.html
@@ -1,0 +1,46 @@
+<!-- Nested node template -->
+<script type="text/ng-template" id="nodes_renderer.html">
+  <div ui-tree-handle class="tree-node tree-node-content">
+    <a class="btn btn-success btn-xs" ng-if="node.nodes && node.nodes.length > 0" data-nodrag ng-click="toggle(this)"><span
+        class="glyphicon"
+        ng-class="{
+          'glyphicon-chevron-right': collapsed,
+          'glyphicon-chevron-down': !collapsed
+        }"></span></a>
+    {{node.title}}
+    <a class="pull-right btn btn-danger btn-xs" data-nodrag ng-click="remove(this)"><span
+        class="glyphicon glyphicon-remove"></span></a>
+    <a class="pull-right btn btn-primary btn-xs" data-nodrag ng-click="newSubItem(this)" style="margin-right: 8px;"><span
+        class="glyphicon glyphicon-plus"></span></a>
+  </div>
+  <ol ui-tree-nodes="" ng-model="node.nodes" ng-class="{hidden: collapsed}">
+    <li ng-repeat="node in node.nodes" ui-tree-node ng-include="'nodes_renderer.html'">
+    </li>
+  </ol>
+</script>
+
+<div class="row">
+  <div class="col-sm-12">
+    <h3>Append Child on Hover Example</h3>
+    <p>
+      The <code>appendChildOnHover</code> property of the <code>treeConfig</code> service can optionally be used to allow inserting a dragged node as a child when hovering over a parent node.
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-6">
+    <div ui-tree id="tree-root">
+      <ol ui-tree-nodes ng-model="data">
+        <li ng-repeat="node in data" ui-tree-node ng-include="'nodes_renderer.html'"></li>
+      </ol>
+    </div>
+  </div>
+
+  <div class="col-sm-6">
+    <div class="info">
+      {{info}}
+    </div>
+    <pre class="code">{{ data | json }}</pre>
+  </div>
+</div>

--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -19,6 +19,7 @@
               hiddenPlaceElm,
               dragElm,
               scrollContainerElm,
+              unhover,
               treeScope = null,
               elements, // As a parameter for callbacks
               dragDelaying = true,
@@ -305,7 +306,11 @@
                 scrollDownBy,
                 scrollUpBy,
                 targetOffset,
-                targetBefore;
+                targetBefore,
+                targetBeforeBuffer,
+                targetHeight,
+                targetChildElm,
+                targetChildHeight;
 
               //If check ensures that drag element was created.
               if (dragElm) {
@@ -529,6 +534,17 @@
 
                   //Check if it is a uiTreeNode or it's an empty tree.
                   if (targetNode.$type !== 'uiTreeNode' && !isEmpty) {
+
+                    // Allow node to return to its original position if no longer hovering over target
+                    if (config.appendChildOnHover) {
+                      next = dragInfo.next();
+                      if (!next && unhover) {
+                        target = dragInfo.parentNode();
+                        target.$element.after(placeElm);
+                        dragInfo.moveTo(target.$parentNodesScope, target.siblings(), target.index() + 1);
+                        unhover = false;
+                      }
+                    }
                     return;
                   }
 
@@ -580,16 +596,28 @@
                     //Get the element of ui-tree-node
                     targetElm = targetNode.$element;
                     targetOffset = UiTreeHelper.offset(targetElm);
+                    targetHeight = UiTreeHelper.height(targetElm);
+                    targetChildElm = targetNode.$childNodesScope ? targetNode.$childNodesScope.$element : null;
+                    targetChildHeight = targetChildElm ? UiTreeHelper.height(targetChildElm) : 0;
+                    targetHeight -= targetChildHeight;
+                    targetBeforeBuffer = config.appendChildOnHover ? targetHeight * 0.25 : UiTreeHelper.height(targetElm) / 2;
                     targetBefore = targetNode.horizontal ? eventObj.pageX < (targetOffset.left + UiTreeHelper.width(targetElm) / 2)
-                      : eventObj.pageY < (targetOffset.top + UiTreeHelper.height(targetElm) / 2);
+                      : eventObj.pageY < (targetOffset.top + targetBeforeBuffer);
 
                     if (targetNode.$parentNodesScope.accept(scope, targetNode.index())) {
                       if (targetBefore) {
                         targetElm[0].parentNode.insertBefore(placeElm[0], targetElm[0]);
                         dragInfo.moveTo(targetNode.$parentNodesScope, targetNode.siblings(), targetNode.index());
                       } else {
-                        targetElm.after(placeElm);
-                        dragInfo.moveTo(targetNode.$parentNodesScope, targetNode.siblings(), targetNode.index() + 1);
+                        // Try to append as a child if dragged upwards onto targetNode
+                        if (config.appendChildOnHover && targetNode.accept(scope, targetNode.childNodesCount())) {
+                          targetNode.$childNodesScope.$element.prepend(placeElm);
+                          dragInfo.moveTo(targetNode.$childNodesScope, targetNode.childNodes(), 0);
+                          unhover = true;
+                        } else {
+                          targetElm.after(placeElm);
+                          dragInfo.moveTo(targetNode.$parentNodesScope, targetNode.siblings(), targetNode.index() + 1);
+                        }
                       }
 
                     //We have to check if it can add the dragging node as a child.

--- a/source/main.js
+++ b/source/main.js
@@ -18,7 +18,8 @@
       dragClass: 'angular-ui-tree-drag',
       dragThreshold: 3,
       levelThreshold: 30,
-      defaultCollapsed: false
+      defaultCollapsed: false,
+      appendChildOnHover: false
     });
 
 })();


### PR DESCRIPTION
This commit adds the ability to append a node as a child to another node via mouse-over. This is particularly useful for target nodes that have no children. The conventional way of adding nodes (dragging horizontally) remains unaffected.

The original code for this commit is based on @matthewboonstra's solution from #505. I edited it to allow moving a dragged node back to its original position after hovering over a preceding parent. I also restored broken horizontal mouse movement functionality and updated the original code based on changes to UiTreeHelper.

Tests with `gulp serve` on Windows 7 x64:
* Successfully executed 25 of 25 unit tests.
* Ran 6 specs, got 0 failures for the E2E-tests.

![2016-06-15_23-21-20](https://cloud.githubusercontent.com/assets/18430599/16104503/f990cd24-334f-11e6-8bf5-3bed17f24bc6.gif)
