### PR TITLE
796 multiple ui tree handles

### DIFF
--- a/source/controllers/nodeCtrl.js
+++ b/source/controllers/nodeCtrl.js
@@ -12,7 +12,7 @@
         $scope.$childNodesScope = null; // uiTreeNodes Scope of child nodes.
         $scope.$parentNodesScope = null; // uiTreeNodes Scope of parent nodes.
         $scope.$treeScope = null; // uiTree scope
-        $scope.$handleScope = null; // it's handle scope
+        $scope.$handleScope = []; // it's handle scope
         $scope.$type = 'uiTreeNode';
         $scope.$$allowNodeDrop = false;
         $scope.collapsed = false;

--- a/source/directives/uiTreeHandle.js
+++ b/source/directives/uiTreeHandle.js
@@ -15,6 +15,11 @@
             if (config.handleClass) {
               element.addClass(config.handleClass);
             }
+            // Store any passed properties in the parent node
+            // object
+            if (attrs.uiTreeHandle.length > 0) {
+              scope.passedObj = scope.$eval(attrs.uiTreeHandle);
+            }
             // connect with the tree node.
             if (scope != treeNodeCtrl.scope) {
               scope.$nodeScope = treeNodeCtrl.scope;

--- a/source/directives/uiTreeHandle.js
+++ b/source/directives/uiTreeHandle.js
@@ -18,7 +18,7 @@
             // connect with the tree node.
             if (scope != treeNodeCtrl.scope) {
               scope.$nodeScope = treeNodeCtrl.scope;
-              treeNodeCtrl.scope.$handleScope = scope;
+              treeNodeCtrl.scope.$handleScope.push(scope);
             }
           }
         };

--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -143,6 +143,9 @@
                 return;
               }
 
+              // Mark the element as the one that got dragged
+              eventElm.prop('activeHandle', true);
+
               e.uiTreeDragging = true; // stop event bubbling
               if (e.originalEvent) {
                 e.originalEvent.uiTreeDragging = true;
@@ -518,6 +521,14 @@
                     .finally(function () {
                       hiddenPlaceElm.replaceWith(scope.$element);
                       placeElm.remove();
+
+                      // Remove the 'activeHandle' property from all
+                      // the node's handles
+                      scope.$handleScope.forEach(function(thisHandle) {
+                        if (typeof thisHandle.$element.prop('activeHandle') != 'undefined') {
+                          thisHandle.$element.removeProp('activeHandle');
+                        }
+                      });
 
                       if (dragElm) { // drag element is attached to the mouse pointer
                         dragElm.remove();


### PR DESCRIPTION
This PR addresses issue #796 

It allows:
- Multiple `uiTreeHandle`s within a single `uiTreeNode`
- The ability to pass an arbitrary object to a `uiTreeHandle`, that object is stored within the handle's scope
- The flagging of which uiTreeHandle is used for dragging an element

The upshot of all this is that it is now possible to have multiple drag handles and know which one was used to drag a node, thereby allowing different actions to be taken in the callbacks