### PR TITLE
Using visible rect for calculating if target should be before or after cursor position.

### DIFF
--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -467,7 +467,7 @@
                     targetElm = targetNode.$element; // Get the element of ui-tree-node
                     targetOffset = UiTreeHelper.offset(targetElm);
                     targetBefore = targetNode.horizontal ? eventObj.pageX < (targetOffset.left + UiTreeHelper.width(targetElm) / 2)
-                      : eventObj.pageY < (targetOffset.top + UiTreeHelper.height(targetElm) / 2);
+                      : eventObj.pageY < (targetOffset.top + targetOffset.height / 2);
 
                     if (targetNode.$parentNodesScope.accept(scope, targetNode.index())) {
                       if (targetBefore) {


### PR DESCRIPTION
When there is a hidden element that is taller than the list item, the placeholder doesn't get dropped in the right place until after the user drags the item more than half the height of the visible list item. This causes issues when trying to drag a list item to the last spot in the list because you can get the out of bounds condition triggered before the placeholder drops into the last spot. This jsfiddle demonstrates part of the issue I am experiencing: http://jsfiddle.net/qzk0o9Lm/