### PR TITLE
Enable setting a numeric value for the expand-on-hover attribute

### DIFF
--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -63,7 +63,7 @@
             });
 
             scope.$watch(attrs.expandOnHover, function(val) {
-              if ((typeof val) == 'boolean') {
+              if ((typeof val) === 'boolean' || (typeof val) === 'number') {
                 scope.expandOnHover = val;
               }
             });


### PR DESCRIPTION
Enable setting a numeric value for the `expand-on-hover` attribute.

**Note:** This PR is created because of #810. The original author is @pkatta.