### PR TITLE
Allow DragElement to scroll any container

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ Injecting `ui.tree`, `ui-tree-nodes`, `ui-tree-node`, `ui-tree-handle` to your h
 
 #### Attributes
 ##### data-nodrop-enabled
-Prevent dropping of nodes into this tree. This applies to both nodes dragged within this tree and nodes from a connected tree. 
-Adding this attribute to the `ui-tree` effectively makes the tree a drag source only. 
+Prevent dropping of nodes into this tree. This applies to both nodes dragged within this tree and nodes from a connected tree.
+Adding this attribute to the `ui-tree` effectively makes the tree a drag source only.
 To prevent a particular node from accepting children, add the attribute to the `ui-tree-nodes` element instead (see below).
 See the [demo page](http://angular-ui-tree.github.io/angular-ui-tree/#/nodrop) for examples.
 - `false` (default): turn off
@@ -194,8 +194,8 @@ Expand all it's child nodes.
 
 #### Methods of scope
 ##### $callbacks (type: Object)
-`$callbacks` is a very important property for `angular-ui-tree`. 
-When some special events trigger, the functions in `$callbacks` are called. 
+`$callbacks` is a very important property for `angular-ui-tree`.
+When some special events trigger, the functions in `$callbacks` are called.
 The callbacks can be passed through the directive.
 
 Example:
@@ -256,7 +256,7 @@ If a node moves it's position after dropped, the `nodeDropped` callback will be 
     + `nodeScope`: The scope of source node which was dragged.
     + `nodesScope`: The scope of the parent nodes of source node  when it began to drag.
     + `index`: The position when it began to drag.
-    + `cloneModel`: Given data-clone-enabled is true, holds the model of the cloned node that is to be inserted, this can be edited before drop without affecting the source node.   
+    + `cloneModel`: Given data-clone-enabled is true, holds the model of the cloned node that is to be inserted, this can be edited before drop without affecting the source node.
   * `dest`: Destination object
     + `nodesScope`: The scope of `ui-tree-nodes` which you just dropped in.
     + `index`: The position you dropped in.
@@ -265,7 +265,7 @@ If a node moves it's position after dropped, the `nodeDropped` callback will be 
     + `dragging`: The dragging element.
   * `pos`: Position object.
 
-To change the node being dropped before 
+To change the node being dropped before
 ##### <a name="dragStart"></a>dragStart(event)
 The `dragStart` function is called when the user starts to drag the node.
 **Parameters:**
@@ -303,12 +303,12 @@ The `toggle` function is called after the node is toggled
 - `sourceNodeScope`: The scope of source node which is toggled.
 
 ### ui-tree-nodes
-`ui-tree-nodes` is the container of nodes. 
+`ui-tree-nodes` is the container of nodes.
 Every `ui-tree-node` should have a `ui-tree-nodes` as it's container, a `ui-tree-nodes` can have multiple child nodes.
 
 #### Attributes
 ##### data-nodrop-enabled <a name="nodes_attrs_nodrop"></a>
-Prevent nodes from being dropped into this node container. 
+Prevent nodes from being dropped into this node container.
 This prevents nodes from being dropped directly into the container with the attribute but not into children that contain additional containers.
 See the [demo page](http://angular-ui-tree.github.io/angular-ui-tree/#/nodrop) for examples.
 
@@ -385,9 +385,20 @@ Collapse the node.
 ##### data-expand-on-hover (type: boolean, number)
 Causes the node to expand (if it contains child nodes and was collapsed) when dragging a node over it.
 This lets users drag and drop items into a nested tree in a single drag operation, instead of having to expand all the nodes to the destination first.
-
 The target node will immediately expand when `true` is provided.
 When a number (in milliseconds) is specified, the target node will expand after the specified amount of milliseconds.
+
+##### data-scroll-container (type: string)
+Causes drag-scrolling to happen within a customisable container, as opposed to the default document body.
+Accepts any selector string that document.querySelector accepts.
+Example:
+```html
+<div ui-tree style="height: 300px; overflow:scroll;" class="wrapper">
+    <ul ui-tree-nodes style="height: 600px;">
+        <li ui-tree-node ng-repeat="item in items" data-scroll-container=".wrapper">
+    </ul>
+</div>
+```
 
 #### Properties of scope
 ##### $element (type: AngularElement)
@@ -455,7 +466,7 @@ Check if the current node is a child of the target node.
 
 
 ### ui-tree-handle
-Use the `ui-tree-handle` to specify an element used to drag the object. 
+Use the `ui-tree-handle` to specify an element used to drag the object.
 If you don't add a `ui-tree-handle` for a node, the entire node can be dragged.
 
 ## Runtime Configuration
@@ -504,7 +515,7 @@ Run the commands below in the project root directory.
 ## Useful commands
 
 ####Running a Local Development Web Server
-To debug code and run end-to-end tests, it is often useful to have a local HTTP server. 
+To debug code and run end-to-end tests, it is often useful to have a local HTTP server.
 For this purpose, we have made available a local web server based on Node.js.
 
 To start the web server, run:
@@ -529,13 +540,13 @@ This will generate non-minified and minified JavaScript files in the `dist` dire
 You can run the unit test using a separate task.
 
     $ gulp test
-    
+
 The E2E-tests can be executed using
-    
+
     $ gulp test:e2e
-    
+
     > Note: make sure you have the example website running on port `9000` (using the `$ gulp serve` command)
-	
+
 *Windows: If your e2e tests are failing, run the command prompt as an administrator. ([See symlink issue](https://github.com/ben-eb/gulp-symlink/issues/33))*
 
 ####Deploy examples

--- a/source/directives/uiTreeNode.spec.js
+++ b/source/directives/uiTreeNode.spec.js
@@ -16,32 +16,59 @@
       }];
     }));
 
-    beforeEach(function () {
-      element = createElement();
-    });
-
-    function createElement() {
-      var template = '<div ui-tree><ol ui-tree-nodes ng-model="items"><li ng-repeat="item in items" ui-tree-node><div ui-tree-handle>{{item.title}}</div></li></ol></div>';
+    function createElement(template) {
+      template = template || '<div ui-tree><ol ui-tree-nodes ng-model="items"><li ng-repeat="item in items" ui-tree-node><div ui-tree-handle>{{item.title}}</div></li></ol></div>';
       element = angular.element(template);
       $compile(element)($scope);
       $scope.$digest();
       return element;
     }
 
-    it('should collapse on receiving the angular-ui-tree:collapse-all event', function () {
-      $rootScope.$broadcast('angular-ui-tree:collapse-all');
-      $scope.$digest();
+    describe('collapsed', function () {
+      beforeEach(function () {
+        element = createElement();
+      });
 
-      expect(element.find('[ui-tree-node]').attr('collapsed')).toEqual('true');
-      expect(element.find('[ui-tree-node]').scope().collapsed).toEqual(true);
+      it('should collapse on receiving the angular-ui-tree:collapse-all event', function () {
+        $rootScope.$broadcast('angular-ui-tree:collapse-all');
+        $scope.$digest();
+
+        expect(element.find('[ui-tree-node]').attr('collapsed')).toEqual('true');
+        expect(element.find('[ui-tree-node]').scope().collapsed).toEqual(true);
+      });
+
+      it('should expand on receiving the angular-ui-tree:expand-all event', function () {
+        $rootScope.$broadcast('angular-ui-tree:expand-all');
+        $scope.$digest();
+
+        expect(element.find('[ui-tree-node]').attr('collapsed')).toEqual('false');
+        expect(element.find('[ui-tree-node]').scope().collapsed).toEqual(false);
+      });
     });
 
-    it('should expand on receiving the angular-ui-tree:expand-all event', function () {
-      $rootScope.$broadcast('angular-ui-tree:expand-all');
-      $scope.$digest();
+    describe('scrollContainer', function() {
+      it('should allow setting an alternative container for scrolling', function () {
+        var element = createElement('<div class="wrapper" ui-tree><ul ui-tree-nodes ng-model="items"><li ng-repeat="item in items" ui-tree-node data-scroll-container=".wrapper"></li></ul></div>');
+        $scope.$digest();
+        expect(element.find('[ui-tree-node]').scope().scrollContainer).toEqual('.wrapper');
+      });
 
-      expect(element.find('[ui-tree-node]').attr('collapsed')).toEqual('false');
-      expect(element.find('[ui-tree-node]').scope().collapsed).toEqual(false);
+      it('should be null by default', function () {
+        var element = createElement();
+        $scope.$digest();
+        expect(element.find('[ui-tree-node]').scope().scrollContainer).toEqual(null);
+      });
+
+      it('should allow changing of the container dynamically', function () {
+        $scope.container = '.wrapper';
+        var element = createElement('<div class="wrapper" ui-tree><ul ui-tree-nodes ng-model="items"><li ng-repeat="item in items" ui-tree-node data-scroll-container="{{container}}"></li></ul></div>');
+        $scope.$digest();
+        expect(element.find('[ui-tree-node]').scope().scrollContainer).toEqual('.wrapper');
+
+        $scope.container = '.foo';
+        $scope.$digest();
+        expect(element.find('[ui-tree-node]').scope().scrollContainer).toEqual('.foo');
+      });
     });
   });
 


### PR DESCRIPTION
Fixes/is related to issues #49, #644, #158 and #544

Changes:
- New ui-tree-node attribute append-to allows for specifying any valid querySelector argument to scroll relative to the dragged node.

Example:

```
<div style="height: 300px; overflow:scroll;" class="wrapper"
    ui-tree>
    <ul style="height: 600px;" 
        ui-tree-nodes>
        <li ng-repeat="item in items"
            ui-tree-node 
            data-append-to="'.wrapper'">
    </ul>
</div>
```