### PR TITLE
Fixed issue scrolling connected trees when loading external templates

### DIFF
--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -96,6 +96,12 @@
               UiTreeHelper.setNodeAttribute(scope, 'scrollContainer', val);
               attrs.$set('scrollContainer', val);
               scrollContainerElm = document.querySelector(val);
+              if (!scrollContainerElm) {
+                $timeout(function() {
+                  scrollContainerElm = document.querySelector(val);
+
+                }, 0);
+              }
             });
 
             scope.$on('angular-ui-tree:collapse-all', function () {
@@ -491,7 +497,7 @@
                 if (moveWithinTree && pos.dirAx) {
 
                   // increase horizontal level if previous sibling exists and is not collapsed
-                  // example 1.1.1 becomes 1.2 
+                  // example 1.1.1 becomes 1.2
                   if (pos.distX > 0) {
                     prev = dragInfo.prev();
                     if (prev && !prev.collapsed
@@ -515,7 +521,7 @@
                       }
                     }
                   }
-                } else { //Either in origin tree and moving horizontally OR you are moving within a new tree.  
+                } else { //Either in origin tree and moving horizontally OR you are moving within a new tree.
 
                   //Check it's new position.
                   isEmpty = false;


### PR DESCRIPTION
Hi guys, I came across this issue and fixed it.
It goes as follow:

1. Create 2 Connected Trees every in a different directive with scrolling.
2. Make each load a template from a url.
3. Execute and observe that the scroll is not working.

Here is a demo that I had to download from fiddle to make the issue happen:
[demo.zip](https://github.com/angular-ui-tree/angular-ui-tree/files/572766/demo.zip)

Note: if you move content from `tree1.html` and `tree2.html` to `index.html` the issue won't occur.

Tests and build worked fine