### PR TITLE
Prevent node being non-collapsable after drag-and-drop in-place

### DIFF
--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -167,7 +167,7 @@
 
               //Check if it or it's parents has a 'data-nodrag' attribute
               el = angular.element(e.target);
-              isUiTreeRoot = false;
+              isUiTreeRoot = el[0].attributes['ui-tree'];
               while (el && el[0] && el[0] !== element && !isUiTreeRoot) {
 
                 //Checking that I can access attributes.

--- a/source/directives/uiTreeNode.js
+++ b/source/directives/uiTreeNode.js
@@ -167,6 +167,7 @@
 
               //Check if it or it's parents has a 'data-nodrag' attribute
               el = angular.element(e.target);
+              isUiTreeRoot = false;
               while (el && el[0] && el[0] !== element && !isUiTreeRoot) {
 
                 //Checking that I can access attributes.


### PR DESCRIPTION
Added isUiTreeRoot = false; in check if it or it's parents has a 'data-nodrag' attribute for preventing become item not selectable after clicking on this item.