### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,54 +1,54 @@
-#2.22.5
+# 2.22.5
 
 * Move postinstall hook to pretest [#907](https://github.com/angular-ui-tree/angular-ui-tree/issues/907)
 
-#2.22.4
+# 2.22.4
 
 * Fixed placeholder height calculating [#904](https://github.com/angular-ui-tree/angular-ui-tree/issues/904)
 * Prevent node being non-collapsable after drag-and-drop in-place [#878](https://github.com/angular-ui-tree/angular-ui-tree/issues/878)
 * Edit Protractor installation [#905](https://github.com/angular-ui-tree/angular-ui-tree/issues/905)
 
-#2.22.3
+# 2.22.3
 
 * Expand-on-hover event not calling toggle callback function [#899](https://github.com/angular-ui-tree/angular-ui-tree/issues/899)
 
-#2.22.2
+# 2.22.2
 
 * Update devDependencies
 * Remove unused outOfBounds calculation [#856](https://github.com/angular-ui-tree/angular-ui-tree/issues/856)
 
-#2.22.1
+# 2.22.1
 
 * Fix tree sorting bug, see Issues [#831](https://github.com/angular-ui-tree/angular-ui-tree/issues/831) and [#832](https://github.com/angular-ui-tree/angular-ui-tree/issues/832)
 
-#2.22.0
+# 2.22.0
 
 * Improve horizontal movement detection for smoother node movement and to address Issue [#562](https://github.com/angular-ui-tree/angular-ui-tree/issues/562)
 
-#2.21.3
+# 2.21.3
 
 * Set `appendChildOnHover` to `true` by default.
 
-#2.21.2
+# 2.21.2
 
 * Re-integrate lost patch from PR [#650](https://github.com/angular-ui-tree/angular-ui-tree/pull/650).
 
-#2.21.1
+# 2.21.1
 
 * Update CHANGELOG.md
 
-#2.21.0
+# 2.21.0
 
 * New ui-tree-node attribute data-scroll-container allows for specifying any valid querySelector argument to scroll relative to the dragged node.
 * Fixes Issues [#49](https://github.com/angular-ui-tree/angular-ui-tree/issues/49), [#644](https://github.com/angular-ui-tree/angular-ui-tree/issues/644), [#158](https://github.com/angular-ui-tree/angular-ui-tree/issues/158), and [#544](https://github.com/angular-ui-tree/angular-ui-tree/issues/544)
 
-#2.20.0
+# 2.20.0
 
 * Performance Improvements by skipping dragDelay when no delay is specified
 * Corrected error with ESC key not cancelling drag [#799](https://github.com/angular-ui-tree/angular-ui-tree/issues/799)
 * Corrected error where dropping on a noDrop clone tree would add node to second tree [Example of Error](http://gfycat.com/EverlastingCanineCleanerwrasse)
 
-#2.19.0
+# 2.19.0
 
 * Fix error caused by version rollback.
 

--- a/README.md
+++ b/README.md
@@ -508,11 +508,11 @@ module.config(function(treeConfig) {
 #### Installation
 Run the commands below in the project root directory.
 
-#####1. Install Gulp and Bower
+##### 1. Install Gulp and Bower
 
     $ sudo npm install -g gulp bower
 
-#####2. Install project dependencies
+##### 2. Install project dependencies
 
     $ npm install
     $ ./node_modules/protractor/bin/webdriver-manager update
@@ -520,7 +520,7 @@ Run the commands below in the project root directory.
 
 ## Useful commands
 
-####Running a Local Development Web Server
+#### Running a Local Development Web Server
 To debug code and run end-to-end tests, it is often useful to have a local HTTP server.
 For this purpose, we have made available a local web server based on Node.js.
 
@@ -535,14 +535,14 @@ To access the local server, enter the following URL into your web browser:
 By default, it serves the contents of the `examples` directory.
 
 
-####Building angular-ui-tree
+#### Building angular-ui-tree
 To build angular-ui-tree, you use the following command.
 
     $ gulp build
 
 This will generate non-minified and minified JavaScript files in the `dist` directory.
 
-####Run tests
+#### Run tests
 You can run the unit test using a separate task.
 
     $ gulp test
@@ -555,6 +555,6 @@ The E2E-tests can be executed using
 
 *Windows: If your e2e tests are failing, run the command prompt as an administrator. ([See symlink issue](https://github.com/ben-eb/gulp-symlink/issues/33))*
 
-####Deploy examples
+#### Deploy examples
 
     $ gulp deploy


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
