### PR TITLE
Prefer $timeout over safeApply. 

### DIFF
--- a/source/controllers/nodesCtrl.js
+++ b/source/controllers/nodesCtrl.js
@@ -3,8 +3,8 @@
 
   angular.module('ui.tree')
 
-    .controller('TreeNodesController', ['$scope', '$element',
-      function ($scope, $element) {
+    .controller('TreeNodesController', ['$scope', '$element', '$timeout',
+      function ($scope, $element, $timeout) {
         this.scope = $scope;
 
         $scope.$element = $element;
@@ -48,22 +48,11 @@
           return $scope.$modelValue.length > 0;
         };
 
-        $scope.safeApply = function (fn) {
-          var phase = this.$root.$$phase;
-          if (phase == '$apply' || phase == '$digest') {
-            if (fn && (typeof (fn) === 'function')) {
-              fn();
-            }
-          } else {
-            this.$apply(fn);
-          }
-        };
-
         //Called in apply method of UiTreeHelper.dragInfo.
         $scope.removeNode = function (node) {
           var index = $scope.$modelValue.indexOf(node.$modelValue);
           if (index > -1) {
-            $scope.safeApply(function () {
+            $timeout(function () {
               $scope.$modelValue.splice(index, 1)[0];
             });
             return $scope.$treeScope.$callbacks.removed(node);
@@ -73,7 +62,7 @@
 
         //Called in apply method of UiTreeHelper.dragInfo.
         $scope.insertNode = function (index, nodeData) {
-          $scope.safeApply(function () {
+          $timeout(function () {
             $scope.$modelValue.splice(index, 0, nodeData);
           });
         };


### PR DESCRIPTION
**Do you want to request a *feature* or report a *bug*?**
Report a bug


**What is the current behavior?**
Occasionally when moving a folder in a ui-tree, the safeApply method throws an error at: 

https://github.com/angular-ui-tree/angular-ui-tree/blob/bc2a301bb54d991542ec58e319fd47c007c25984/source/controllers/nodesCtrl.js#L52

error: Cannot read property $$phase of null

It would seem that this happens only occasionally because the $scope has already been destroyed when reaching this line. I have only been able to replicate this a very few times myself by just moving folders around waiting for the error to happen.

I was doing some research on $$phase and came across this comment:
https://stackoverflow.com/questions/22216441/what-is-the-difference-between-scope-root-and-rootscope#comment47424459_22217937

> @canerbalci in angular 1.4, root scope is allowed to be destroyed, [using] this.$root will point to null after root scope be destroyed

I also found this thread that advised to use $timeout for a safe apply instead:
https://stackoverflow.com/a/21611534/2117683


**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem via https://plnkr.co or similar.**
In my case, I had to keep moving folders around and wait for the error to occur as it only occurs when the scope has been destroyed before hitting safeApply.


**What is the expected behavior?**
To move a folder without error


**What is the motivation / use case for changing the behavior?**
Prevent the error using a $timeout instead of safeApply with $$phase


**Which versions of Angular, UI Tree and which browser / OS are affected by this issue? Did this work in previous versions of Angular, UI Tree? Please also test with the latest version.**
angular-ui-tree 2.22.5
angular 1.5.10


**Other information (e.g. stacktraces, related issues, suggestions how to fix)**
