### PR TITLE
check to make sure node being removed is intended node

### DIFF
--- a/source/controllers/nodesCtrl.js
+++ b/source/controllers/nodesCtrl.js
@@ -53,7 +53,8 @@
           var index = $scope.$modelValue.indexOf(node.$modelValue);
           if (index > -1) {
             $timeout(function () {
-              $scope.$modelValue.splice(index, 1)[0];
+              if ($scope.$modelValue[index] == node.$modelValue)
+                $scope.$modelValue.splice(index, 1)[0];
             });
             return $scope.$treeScope.$callbacks.removed(node);
           }

--- a/source/controllers/nodesCtrl.js
+++ b/source/controllers/nodesCtrl.js
@@ -53,8 +53,9 @@
           var index = $scope.$modelValue.indexOf(node.$modelValue);
           if (index > -1) {
             $timeout(function () {
-              if ($scope.$modelValue[index] == node.$modelValue)
+              if ($scope.$modelValue[index] == node.$modelValue){
                 $scope.$modelValue.splice(index, 1)[0];
+              }
             });
             return $scope.$treeScope.$callbacks.removed(node);
           }


### PR DESCRIPTION
In the nodesCtrl.js the removeNode function doesn't check the index before splicing the array, this was creating issues in my application because I remove node on drop event in one controller and then this removeNode would fire and end up removing an unintended node because by the time it calls splice the index represents a different node.

